### PR TITLE
show redirect url

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -73,7 +73,16 @@ internals.proxy = function (limiter) {
           passThrough: true,
           timeout: 20000,
           uri: request.query.url,
-          redirects: internals.parseRedirects(request.query.r)
+          redirects: internals.parseRedirects(request.query.r),
+          onResponse: function (err, res, request, reply, settings, ttl) {
+            if (err) {
+              err.output.payload.url = err.data[1].url;
+              return reply(err);
+            }
+            return reply(res)
+                  .ttl(ttl)
+                  .passThrough(settings.passThrough || false);   // Default to false
+          }
         });
       });
     }


### PR DESCRIPTION
When number of redirects is limited and gets exceeded, there is no way to tell what url was it going to go to. 
